### PR TITLE
docker dev workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ target/
 !.mvn/wrapper/maven-wrapper.jar
 !**/src/main/**/target/
 !**/src/test/**/target/
+.m2/
 
 ### STS ###
 .apt_generated

--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,5 @@
+# build jar with maven
+docker run --rm -it -v ${PWD}:/app -v ${PWD}/.m2:/root/.m2/ maven:3.6.3-jdk-11 bash -c " cd /app && mvn -B package --file pom.xml"
+# test it out
+docker-compose down || /bin/true
+docker-compose up --build -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: "2.1"
+services:
+  mariadb:
+    image: ghcr.io/linuxserver/mariadb
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - MYSQL_ROOT_PASSWORD=test
+      - TZ=America/New_York
+      - MYSQL_DATABASE=gotthere_database
+      - MYSQL_USER=remote
+      - MYSQL_PASSWORD=test
+    ports:
+      - 3333:3306
+    volumes:
+      - "${PWD}/initdb.d/:/config/initdb.d/"
+    restart: unless-stopped
+  gotthere:
+    build: .
+    command: "bash -c 'sleep 10 && java -jar -Dspring.datasource.url=jdbc:mariadb://mariadb:3306/gotthere_database gotthere_server-0.0.1-SNAPSHOT.jar'"
+    restart: unless-stopped
+    ports:
+      - 2810:2810/udp
+      - 8080:8080
+    depends_on:
+      - mariadb

--- a/initdb.d/dev.sql
+++ b/initdb.d/dev.sql
@@ -1,0 +1,9 @@
+USE gotthere_database;
+
+CREATE TABLE `user` (
+	id int(11) PRIMARY KEY AUTO_INCREMENT,
+	username VARCHAR(255) NOT NULL,
+	password VARCHAR(255) NOT NULL
+);
+
+INSERT INTO `user` (username, password) VALUES ('admin','admin');


### PR DESCRIPTION
This change let's you do a few cool things:

On a linux host, run `./dev.sh`.

This builds a copy of `gotthere.jar` in the `target/` directory. It caches the `.m2` directory for maven, so it only downloads maven deps once. It then deploys a dev workstation with `docker-compose`.

`docker-compose.yml` contains a dedicated `mariadb` server, that is prepopulated with a user account `admin/admin` (sourced from `initdb.d/*`.

You can go to port `8080` on localhost to see your local copy of `gotthere`. Port `2810` is also forwarded.

This lets you, with one command, generate a completely isolated copy of `gotthere` for testing.

All the data goes away when you rebuild the world with `./dev.sh`. We 'could' make it so the database files are persistent...we'll see.